### PR TITLE
[fix ext typo]

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "hashicorp.terraform",
-    "ms-azurertools.vscode-azureterraform"
+    "ms-azuretools.vscode-azureterraform"
   ]
 }


### PR DESCRIPTION
Fix typo in .vscode/extensions.json: `ms-azurertools` -> `ms-azuretools`